### PR TITLE
feat: Added logic to compress cards when stacks are large

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+### v1.7.9 - Prevent Off-Screen Tableau Cards
+
+Fixed issue #83 where tall tableau piles could render cards below the bottom of the screen.
+
+**Changes:**
+- Added dynamic pile compression so card spacing shrinks when a pile grows too tall
+- Kept rendering, hover, selection overlay, and click hit-testing aligned with the same pile layout logic
+- Added a configurable minimum compressed gap (`MinCardStackGap`) for readability tuning
+
+This keeps piles playable in late-game states without cards disappearing off-screen.
+
 ### v1.7.8 - Visual Stock Pile with Click-to-Deal
 
 Added interactive stock pile visual in bottom-right corner for mouse-based card dealing.

--- a/internal/ui/game.go
+++ b/internal/ui/game.go
@@ -234,19 +234,23 @@ func (g *Game) hitTest(mx, my int) (pileIdx, cardIdx int, ok bool) {
 			// no cards and click outside base area: continue searching
 			continue
 		}
+
+		layout := computeTableauPileLayout(g.theme, len(pile.Cards))
+
 		// Cards overlap; check top-most first
 		for j := len(pile.Cards) - 1; j >= 0; j-- {
-			cy := y + j*g.theme.Layout.CardStackGap
+			cy := layout.CardY[j]
 			if mx >= x && mx < x+g.theme.Layout.CardWidth && my >= cy && my < cy+g.theme.Layout.CardHeight {
 				return i, j, true
 			}
 		}
 		// if clicking below all cards but within column, treat as click on topmost card area
-		// Allow a small margin (one CardStackGap) below the bottom of the top card for easier targeting
+		// Allow a small margin below the bottom card for easier targeting.
+		// Tie this to computed gap so hit-testing matches compressed rendering.
 		if len(pile.Cards) > 0 {
-			topY := y + (len(pile.Cards)-1)*g.theme.Layout.CardStackGap
+			topY := layout.CardY[len(pile.Cards)-1]
 			bottomY := topY + g.theme.Layout.CardHeight
-			clickMarginBelow := g.theme.Layout.CardStackGap // 30px margin
+			clickMarginBelow := max(layout.Gap, 8)
 			if mx >= x && mx < x+g.theme.Layout.CardWidth && my >= bottomY && my < bottomY+clickMarginBelow {
 				return i, len(pile.Cards) - 1, true
 			}

--- a/internal/ui/pile_layout.go
+++ b/internal/ui/pile_layout.go
@@ -1,0 +1,75 @@
+package ui
+
+// pileLayout describes computed vertical placement for cards in a tableau pile.
+type pileLayout struct {
+	Gap   int   // vertical distance between adjacent card origins
+	CardY []int // y-origin for each card index in the pile
+}
+
+const (
+	// defaultMinCompressedCardStackGap is used when theme does not specify a minimum.
+	defaultMinCompressedCardStackGap = 10
+	// pileBottomPadding reserves pixels below the last card. Keep 0 to maximize usable space.
+	pileBottomPadding = 0
+)
+
+// computePileLayout calculates per-pile vertical card placement.
+//
+// Behavior:
+// - Uses defaultGap when the pile fits.
+// - Compresses gap when the pile would overflow.
+// - Prioritizes keeping the last card fully visible on screen.
+func computePileLayout(cardCount, startY, cardHeight, logicalHeight, defaultGap, minGap, bottomPadding int) pileLayout {
+	if cardCount <= 0 {
+		return pileLayout{Gap: defaultGap, CardY: nil}
+	}
+
+	if cardCount == 1 {
+		return pileLayout{Gap: defaultGap, CardY: []int{startY}}
+	}
+
+	available := logicalHeight - bottomPadding - startY - cardHeight
+	if available < 0 {
+		available = 0
+	}
+
+	steps := cardCount - 1
+	maxVisibleGap := available / steps // largest gap that still keeps last card visible
+
+	gap := min(maxVisibleGap, defaultGap)
+
+	if gap < minGap {
+		// Apply readability floor only when it still fits.
+		if minGap*steps <= available {
+			gap = minGap
+		} else {
+			// Visibility has priority over readability floor.
+			gap = max(maxVisibleGap, 1)
+		}
+	}
+
+	cardY := make([]int, cardCount)
+	for i := 0; i < cardCount; i++ {
+		cardY[i] = startY + i*gap
+	}
+
+	return pileLayout{Gap: gap, CardY: cardY}
+}
+
+// computeTableauPileLayout computes pile layout from theme defaults.
+func computeTableauPileLayout(theme *Theme, cardCount int) pileLayout {
+	minGap := defaultMinCompressedCardStackGap
+	if theme.Layout.MinCardStackGap > 0 {
+		minGap = theme.Layout.MinCardStackGap
+	}
+
+	return computePileLayout(
+		cardCount,
+		theme.Layout.TableauStartY,
+		theme.Layout.CardHeight,
+		theme.Layout.LogicalHeight,
+		theme.Layout.CardStackGap,
+		minGap,
+		pileBottomPadding,
+	)
+}

--- a/internal/ui/pile_layout_test.go
+++ b/internal/ui/pile_layout_test.go
@@ -1,0 +1,97 @@
+package ui
+
+import "testing"
+
+func TestComputePileLayout_UsesDefaultGapWhenPileFits(t *testing.T) {
+	layout := computePileLayout(
+		5,   // cardCount
+		150, // startY
+		120, // cardHeight
+		720, // logicalHeight
+		30,  // defaultGap
+		8,   // minGap
+		0,   // bottomPadding
+	)
+
+	if layout.Gap != 30 {
+		t.Fatalf("expected default gap 30, got %d", layout.Gap)
+	}
+
+	if got, want := layout.CardY[len(layout.CardY)-1], 270; got != want {
+		t.Fatalf("expected last card Y %d, got %d", want, got)
+	}
+}
+
+func TestComputePileLayout_CompressesWhenPileWouldOverflow(t *testing.T) {
+	layout := computePileLayout(
+		20,  // cardCount
+		150, // startY
+		120, // cardHeight
+		720, // logicalHeight
+		30,  // defaultGap
+		8,   // minGap
+		0,   // bottomPadding
+	)
+
+	// available = 450, steps = 19, maxVisibleGap = 23
+	if layout.Gap != 23 {
+		t.Fatalf("expected compressed gap 23, got %d", layout.Gap)
+	}
+
+	lastY := layout.CardY[len(layout.CardY)-1]
+	lastBottom := lastY + 120
+	if lastBottom > 720 {
+		t.Fatalf("expected last card bottom <= 720, got %d", lastBottom)
+	}
+}
+
+func TestComputePileLayout_VisibilityWinsWhenMinGapCannotFit(t *testing.T) {
+	layout := computePileLayout(
+		80,  // cardCount
+		150, // startY
+		120, // cardHeight
+		720, // logicalHeight
+		30,  // defaultGap
+		8,   // minGap
+		0,   // bottomPadding
+	)
+
+	if layout.Gap < 1 {
+		t.Fatalf("expected gap >= 1, got %d", layout.Gap)
+	}
+
+	lastY := layout.CardY[len(layout.CardY)-1]
+	lastBottom := lastY + 120
+	if lastBottom > 720 {
+		t.Fatalf("expected last card bottom <= 720, got %d", lastBottom)
+	}
+}
+
+func TestComputeTableauPileLayout_UsesThemeDefaults(t *testing.T) {
+	theme := DefaultTheme
+	layout := computeTableauPileLayout(&theme, 20)
+
+	if layout.Gap != 23 {
+		t.Fatalf("expected tableau gap 23, got %d", layout.Gap)
+	}
+}
+
+func TestComputeTableauPileLayout_UsesConfiguredMinGapWhenNeeded(t *testing.T) {
+	theme := DefaultTheme
+	theme.Layout.MinCardStackGap = 12
+
+	// For 40 cards: available=450, steps=39, maxVisibleGap=11.
+	// Min gap cannot fit, so visibility must win and use 11.
+	layout := computeTableauPileLayout(&theme, 40)
+	if layout.Gap != 11 {
+		t.Fatalf("expected visibility gap 11, got %d", layout.Gap)
+	}
+
+	// For 30 cards: available=450, steps=29, maxVisibleGap=15.
+	// Compression is required, but maxVisibleGap is already above min gap.
+	// The algorithm keeps the tightest visible spacing (15).
+	layout = computeTableauPileLayout(&theme, 30)
+	if layout.Gap != 15 {
+		t.Fatalf("expected compressed gap 15, got %d", layout.Gap)
+	}
+}

--- a/internal/ui/rendering.go
+++ b/internal/ui/rendering.go
@@ -49,13 +49,14 @@ func drawPile(screen *ebiten.Image, pile game.PileDTO, x, y int, atlas *CardAtla
 		showHover = pile.Cards[hoveredCardIdx].FaceUp
 	}
 
+	layout := computeTableauPileLayout(theme, len(pile.Cards))
+
 	for i, card := range pile.Cards {
 		// Skip cards that are part of a selection (they'll be drawn lifted by drawSelectionOverlay)
 		if isSelected && i >= selectedIndex {
 			continue
 		}
-		// stack the cards vertically with a small gap
-		cardY := y + i*theme.Layout.CardStackGap
+		cardY := layout.CardY[i]
 		drawCard(screen, card, x, cardY, atlas, theme)
 		// Draw hover overlay on hovered card and all face-up cards below it (the selectable sequence)
 		// Only if the hovered card itself is face-up
@@ -179,10 +180,10 @@ func drawSelectionOverlay(screen *ebiten.Image, view game.GameViewDTO, pileIdx, 
 		return
 	}
 	x := theme.Layout.TableauStartX + pileIdx*theme.Layout.PileSpacing
-	y := theme.Layout.TableauStartY
+	layout := computeTableauPileLayout(theme, len(pile.Cards))
 
 	for i := selectedIndex; i < len(pile.Cards); i++ {
-		cy := y + i*theme.Layout.CardStackGap - theme.Layout.SelectionLiftPx
+		cy := layout.CardY[i] - theme.Layout.SelectionLiftPx
 		// Redraw the card at the lifted position
 		drawCard(screen, pile.Cards[i], x, cy, atlas, theme)
 		// Gold tint overlay

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -12,6 +12,7 @@ type Layout struct {
 	CardHeight           int
 	PileSpacing          int
 	CardStackGap         int
+	MinCardStackGap      int
 	TableauStartX        int
 	TableauStartY        int
 	StatsX               int
@@ -53,6 +54,7 @@ var DefaultTheme = Theme{
 		CardHeight:           120,
 		PileSpacing:          100,
 		CardStackGap:         30,
+		MinCardStackGap:      10,
 		TableauStartX:        50,
 		TableauStartY:        150,
 		StatsX:               20,


### PR DESCRIPTION
  - This uses a module called pile layout to render the cards based on how many are in a pile
  - The rendering and hit features now both share this logic so we are consistent and out hit area is not mucked up by the compression